### PR TITLE
feat(auth): Check for admin permissions before calling exportmembers

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -1,7 +1,18 @@
 from discord import Member
+from discord.ext import commands
 from typing import List
 from csv import DictWriter
 import os
+
+class NotAdminError(commands.CheckFailure):
+    pass
+
+def is_admin():
+	async def predicate(ctx):
+		if not ctx.author.guild_permissions.administrator:
+			raise NotAdminError("Sorry, this information is need-to-know.")
+		return True
+	return commands.check(predicate)
 
 def generate_csv(members: List[Member]) -> str:
 	if not os.path.isdir("output"):

--- a/bot.py
+++ b/bot.py
@@ -92,13 +92,26 @@ async def get_random(ctx):
 async def set_daily(ctx):
 	await ctx.send()
 
-# @bot.command(name = 'exportmembers', help = 'Sends a CSV with guild members to caller.')
-# async def export_members(ctx):
-# 	author = ctx.author
-# 	csvfilename = admin.generate_csv(ctx.guild.members)
-# 	file = discord.File(csvfilename)
-# 	await author.send(content="Here's a list of your compatriats.", file=file)
+# Hide command from default help message.
+# Command can only be used publicly by admins.
+@bot.command(name = 'exportmembers', hidden = True)
+@commands.guild_only()
+@admin.is_admin()
+async def export_members(ctx):
+	"""
+	*Admin only* Sends a CSV of guild members to caller.
+	"""
+	author = ctx.author
+	csvfilename = admin.generate_csv(ctx.guild.members)
+	file = discord.File(csvfilename)
+	await author.send(content="Here's a list of your compatriats.", file=file)
 
+@export_members.error
+async def export_members_error(ctx, error):
+	if isinstance(error, admin.NotAdminError):
+		await ctx.author.send(error)
+	elif isinstance(error, commands.NoPrivateMessage):
+		await ctx.author.send(error)
 
 """
 Because leetcode doesn't have an easy access API to recieve the problems


### PR DESCRIPTION
# Changes
* Add `guild_only` and `is_admin` checks to `export_members` command to ensure command can only be used publicly by an admin